### PR TITLE
Update FreshservicePS.psm1 - Non-Windows OS

### DIFF
--- a/FreshservicePS/FreshservicePS.psm1
+++ b/FreshservicePS/FreshservicePS.psm1
@@ -1,7 +1,12 @@
 Add-Type -AssemblyName System.Web
 
 $Global:FreshServiceModuleName = $MyInvocation.MyCommand.Name -replace '.psm1'
-$Global:FreshServiceConfigPath = ('{0}\{1}\{1}.config' -f $env:APPDATA,$FreshServiceModuleName)
+if ($IsWindows) {
+    $Global:FreshServiceConfigPath = ('{0}\{1}\{1}.config' -f $env:APPDATA,$FreshServiceModuleName)
+}
+else {
+    $Global:FreshServiceConfigPath = ('{0}/{1}/{1}.config' -f $env:HOME,$FreshServiceModuleName)
+}
 
 # Dot source public/private functions
 $public  = @(Get-ChildItem -Path (Join-Path -Path $PSScriptRoot -ChildPath 'Public/*.ps1')  -Recurse -ErrorAction Stop)


### PR DESCRIPTION
Add logic to creation of $FreshServiceConfigPath global variable to change the config file creation location when on non-Windows OS's.

## Description
<!--- Describe your changes in detail -->
Added if-else block to provide different path option for non-Windows OS's. Used automatic variable "$IsWindows" to determine if OS is Windows and set config file path accordingly. Else block uses "$env:HOME" on non-Windows OS's.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
Issue number 3

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Running FreshservicePS on non-Windows OS's

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran on macOS 13.5.1, PowerShell Core 7.3.6 successfully

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

