### PR TITLE
Added Support for Server Core UseBasicParsing.

### DIFF
--- a/FreshservicePS/Private/Invoke-FreshworksRestMethod.ps1
+++ b/FreshservicePS/Private/Invoke-FreshworksRestMethod.ps1
@@ -153,6 +153,12 @@ function Invoke-FreshworksRestMethod {
                 ErrorAction = 'Stop'
             }
 
+
+            #Support for ServerCore, requires BasicParsing. Get-ComputerInfo is avoided due to performance each time the cmdlet is called.
+            if((Get-ItemProperty "HKLM:\Software\Microsoft\Windows NT\CurrentVersion" InstallationType).InstallationType -eq "Server Core"){
+                $restParams.Add('UseBasicParsing', $true)
+            }
+
             if ( $Body ) {
                 $restParams.Add( 'Body', $Body )
             }


### PR DESCRIPTION
## Description
When using Server Core with FreshservicePS we can't issue any commands without trigging the exception.
Server core doesn't have Internet Explorer Invoke-WebRequest or Invoke-RestMethod require the parameter -UseBasicParsing

## Related Issue
 https://github.com/flycastpartnersinc/FreshservicePS/issues/5

## Motivation and Context
We run Server Core for Automation workers and want to use your awesome modules!

## How Has This Been Tested?
I've tested added statement on Client OS, Server OS and Server Core OS.

## Screenshots (if appropriate):

## Types of changes
- [ x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [] All new and existing tests passed.

